### PR TITLE
Fix 핫딜 수정/생성 이미지 관리 개선 및 temp 이미지 삭제 정책 강화

### DIFF
--- a/src/main/java/com/cherrypick/backend/domain/deal/dto/request/DealUpdateRequestDTO.java
+++ b/src/main/java/com/cherrypick/backend/domain/deal/dto/request/DealUpdateRequestDTO.java
@@ -9,7 +9,7 @@ import java.util.List;
 public record DealUpdateRequestDTO(
 
         Long dealId,
-        List<ImageUrl> imageUrls,
+        List<Long> imageIds,
         String title,
         Long categoryId,
         String originalUrl,

--- a/src/main/java/com/cherrypick/backend/domain/image/entity/Image.java
+++ b/src/main/java/com/cherrypick/backend/domain/image/entity/Image.java
@@ -3,10 +3,15 @@ package com.cherrypick.backend.domain.image.entity;
 import com.cherrypick.backend.domain.image.enums.ImageType;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter @RequiredArgsConstructor
 @Setter @AllArgsConstructor @Builder
+@EntityListeners(AuditingEntityListener.class)
 public class Image {
 
     @Id
@@ -23,4 +28,9 @@ public class Image {
     private int imageIndex;
 
     private boolean isTemp;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
 }

--- a/src/main/java/com/cherrypick/backend/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/cherrypick/backend/domain/image/repository/ImageRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -23,6 +24,9 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
     // 이미지 조회
     @Query(value = "SELECT * FROM image WHERE ref_id=:refId and image_type='USER'", nativeQuery = true)
     Optional<Image> findByUserId(@Param("refId")Long refId);
+
+    // temp 이미지 삭제용으로 생성된지 일정시간 지난 이미지 조회
+    List<Image> findByIsTempTrueAndCreatedAtBefore(LocalDateTime threshold);
 
     @Query("""
     SELECT i FROM Image i


### PR DESCRIPTION
## 📝 요약(Summary)
- 핫딜 수정 API가 정상 호출되기 전 이미지 삭제 API가 먼저 수행되면 문제가 발생할 수 있음
- 따라서 핫딜 수정 API 내에서 이미지 리스트를 전달 받아 사용되지 않는 이미지는 temp 이미지로 변경하게끔 수정
- 핫딜 수정 API에서 기존엔 imageUrls 객체로 요청 받았으나 간편화하기 위해 이미지 ID 리스트로만 요청받도록 수정
- 핫딜 생성, 수정 API 모두 리스트로 받아온 이미지 ID 순서대로 index값을 0부터 자동 저장 (request 값 간소화하기 위해)

- 매일 새벽 3시 temp 이미지를 삭제하는 스케줄러 -> 2시 59분경 유저가 게시글을 작성하려고 할 시 문제가 발생할 수 있음
- 이미지 엔터티에 생성일자 필드를 생성해 생성된지 24시간 이상 된 이미지만 스케줄러가 작동되게끔 함 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
- index를 받을 필요가 없어져서 추후 은수님과 협의 후에 이미지 생성 API에서 index를 request 하는 부분은 삭제할 예정

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 제목을 컨벤션에 맞게 작성했습니다.
- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).